### PR TITLE
Fix scaling and shape issues in spatialdata reader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ include = [
 packages = ["wsidata", "README.md", "LICENSE", "pyproject.toml"]
 
 [tool.ruff]
-lint.ignore = ["F401"]
 lint.extend-select = ["I"]
 line-length = 88
 

--- a/wsidata/_model/__init__.py
+++ b/wsidata/_model/__init__.py
@@ -1,1 +1,3 @@
 from .core import TileSpec, WSIData
+
+__all__ = ["TileSpec", "WSIData"]

--- a/wsidata/accessors/__init__.py
+++ b/wsidata/accessors/__init__.py
@@ -2,3 +2,10 @@ from .dataset import DatasetAccessor
 from .fetch import FetchAccessor
 from .iter import IterAccessor
 from .register import register_wsidata_accessor
+
+__all__ = [
+    "DatasetAccessor",
+    "FetchAccessor",
+    "IterAccessor",
+    "register_wsidata_accessor",
+]

--- a/wsidata/dataset/__init__.py
+++ b/wsidata/dataset/__init__.py
@@ -2,3 +2,10 @@ from .feature import TileFeatureDataset
 from .graph import graph_data
 from .image import TileImagesDataset
 from .multislides import FeaturesDatasetBuilder
+
+__all__ = [
+    "TileFeatureDataset",
+    "TileImagesDataset",
+    "FeaturesDatasetBuilder",
+    "graph_data",
+]

--- a/wsidata/dataset/disk.py
+++ b/wsidata/dataset/disk.py
@@ -1,2 +1,0 @@
-import json
-from pathlib import Path

--- a/wsidata/dataset/multislides/__init__.py
+++ b/wsidata/dataset/multislides/__init__.py
@@ -1,2 +1,9 @@
 from .builder import FeaturesDatasetBuilder
 from .sampler import InSlideUnderSampler, NoBalance, RandomUnderSampler
+
+__all__ = [
+    "FeaturesDatasetBuilder",
+    "InSlideUnderSampler",
+    "NoBalance",
+    "RandomUnderSampler",
+]

--- a/wsidata/io/__init__.py
+++ b/wsidata/io/__init__.py
@@ -10,3 +10,18 @@ from ._elems import (
     update_shapes_data,
 )
 from ._wsi import agg_wsi, concat_feature_anndata, open_wsi
+
+__all__ = [
+    "add_tiles",
+    "add_table",
+    "add_shapes",
+    "add_tissues",
+    "add_features",
+    "agg_wsi",
+    "add_agg_features",
+    "concat_feature_anndata",
+    "open_wsi",
+    "subset_tiles",
+    "sync_tile_spec",
+    "update_shapes_data",
+]

--- a/wsidata/reader/__init__.py
+++ b/wsidata/reader/__init__.py
@@ -17,3 +17,18 @@ if zarr_version.major >= 3:
     from ._reader_datatree_zarr_v3 import to_datatree
 else:
     from ._reader_datatree_zarr_v2 import to_datatree
+
+__all__ = [
+    "version",
+    "Version",
+    "READERS",
+    "ReaderBase",
+    "OpenSlideReader",
+    "SlideProperties",
+    "BioFormatsReader",
+    "CuCIMReader",
+    "FastSlideReader",
+    "SpatialDataImage2DReader",
+    "TiffSlideReader",
+    "to_datatree",
+]

--- a/wsidata/reader/_reader_datatree_zarr_v3.py
+++ b/wsidata/reader/_reader_datatree_zarr_v3.py
@@ -41,6 +41,7 @@ class SlideZarrStore(Store):
         self.chunks = tuple(chunks)
         self.channels = 3
 
+        # self._reader.properties.level_shape is List[(height, width)]
         self._level_shape = list(self._reader.properties.level_shape)
         self._level_downsample = list(self._reader.properties.level_downsample)
         self.n_level = self._reader.properties.n_level
@@ -99,7 +100,7 @@ class SlideZarrStore(Store):
         We expose shape as (height, width, channels) and chunk shape (ch_h, ch_w, channels).
         dtype fixed as uint8 for typical H&E/brightfield slides.
         """
-        w, h = self._level_shape[level]
+        h, w = self._level_shape[level]
         ch_h, ch_w = self.chunks
         channels = self.channels
         shape = [h, w, channels]
@@ -132,7 +133,6 @@ class SlideZarrStore(Store):
           - "{level}/{row}.{col}" (chunk)
         """
         await self._ensure_open()
-        assert self._slide is not None
 
         # group metadata
         if key == ".zgroup":
@@ -157,7 +157,7 @@ class SlideZarrStore(Store):
         # validate level
         if level < 0 or level >= len(self._level_shape):
             return None
-        w, h = self._level_shape[level]
+        h, w = self._level_shape[level]
         ch_h, ch_w = self.chunks
 
         # chunk pixel dimensions (may be smaller at edges)
@@ -172,8 +172,7 @@ class SlideZarrStore(Store):
         y0 = row * ch_h * downsample
 
         arr = await asyncio.to_thread(
-            self.reader.read_region,
-            self._slide,
+            self._reader.get_region,
             x0,
             y0,
             chunk_w,
@@ -219,7 +218,7 @@ class SlideZarrStore(Store):
         level, row, col = parsed
         if not (0 <= level < len(self._level_shape)):
             return False
-        w, h = self._level_shape[level]
+        h, w = self._level_shape[level]
         ch_h, ch_w = self.chunks
         max_row = math.ceil(h / ch_h) - 1
         max_col = math.ceil(w / ch_w) - 1
@@ -239,7 +238,7 @@ class SlideZarrStore(Store):
         yield ".zgroup"
         for lvl in range(len(self._level_shape)):
             yield f"{lvl}/.zarray"
-            w, h = self._level_shape[lvl]
+            h, w = self._level_shape[lvl]
             ch_h, ch_w = self.chunks
             rows = math.ceil(h / ch_h)
             cols = math.ceil(w / ch_w)
@@ -272,9 +271,9 @@ class SlideZarrStore(Store):
                 yield next_token
 
     def close(self) -> None:
-        if self._slide is not None:
+        if self._reader is not None:
             try:
-                self._slide.close()
+                self._reader.detach_reader()
             except Exception:
                 pass
         super().close()
@@ -290,14 +289,14 @@ async def _fetch_chunk_as_array(
         # produce an array of zeros of the expected shape
         ch_h, ch_w = store.chunks
         channels = store.channels
-        w, h = store._level_dims[level]
+        h, w = store._level_shape[level]
         chunk_w = min(ch_w, w - col * ch_w)
         chunk_h = min(ch_h, h - row * ch_h)
         return np.zeros((chunk_h, chunk_w, channels), dtype=np.uint8)
     # Buffer 'buf' supports the buffer protocol; convert to numpy
     b = bytes(buf)
     # compute the expected shape
-    w, h = store._level_dims[level]
+    h, w = store._level_shape[level]
     ch_h, ch_w = store.chunks
     chunk_w = min(ch_w, w - col * ch_w)
     chunk_h = min(ch_h, h - row * ch_h)
@@ -312,7 +311,7 @@ def level_to_xarray(store: SlideZarrStore, level: int):
     Return an xarray.DataArray for the given level.
     This function is synchronous: it uses asyncio.run for simplicity; adjust if you already have an event loop.
     """
-    w, h = store._level_shape[level]
+    h, w = store._level_shape[level]
     ch_h, ch_w = store.chunks
     channels = store.channels
 

--- a/wsidata/reader/spatialdata_image2d.py
+++ b/wsidata/reader/spatialdata_image2d.py
@@ -1,9 +1,8 @@
-from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import cv2
 
-from .base import AssociatedImages, ReaderBase, SlideProperties, convert_image
+from .base import ReaderBase, SlideProperties
 
 if TYPE_CHECKING:
     from spatialdata.models import Image2DModel
@@ -112,17 +111,16 @@ class SpatialDataImage2DReader(ReaderBase):
             img = self.img
 
         downsample_factor = self.properties.level_downsample[level]
-        # SpatialData coordinates must be translated to the respective level
-        x = x / downsample_factor
-        y = y / downsample_factor
-        width = width / downsample_factor
-        height = height / downsample_factor
         if self.is_multiscale:
             data = img.sel(
-                y=slice(y, y + height), x=slice(x, x + width)
+                y=slice(y, y + height * downsample_factor),
+                x=slice(x, x + width * downsample_factor),
             ).image.data.compute()
         else:
-            data = img.sel(y=slice(y, y + height), x=slice(x, x + width)).data.compute()
+            data = img.sel(
+                y=slice(y, y + height * downsample_factor),
+                x=slice(x, x + width * downsample_factor),
+            ).data.compute()
         return data.transpose(1, 2, 0)
 
     def get_thumbnail(self, size, **kwargs):

--- a/wsidata/reader/spatialdata_image2d.py
+++ b/wsidata/reader/spatialdata_image2d.py
@@ -142,7 +142,7 @@ class SpatialDataImage2DReader(ReaderBase):
                 break
         # Get the image at that level
         img = self.get_level(ix)
-        img = cv2.resize(img, size)
+        img = cv2.resize(img, size[::-1], interpolation=cv2.INTER_AREA)
         return img
 
     def detach_reader(self):


### PR DESCRIPTION
Closes #48

### Summary

This pull request addresses key issues in the spatialdata reader:
- Fixes a coordinate scaling issue.
- Corrects handling of wrong shapes when using spatialdata as a reader.
- Improves the quality of thumbnail images for better clarity.
- Removes unnecessary F401 ignore and reformats the code for cleaner style.