### PR TITLE
Fix write() zeroing existing images when overwriting same store (fixes #52)

### DIFF
--- a/wsidata/_model/core.py
+++ b/wsidata/_model/core.py
@@ -16,6 +16,7 @@ from ome_zarr.io import parse_url
 from PIL.Image import Image, fromarray
 from spatialdata import SpatialData
 from spatialdata.models import SpatialElement
+from xarray import DataArray
 
 from .._utils import find_stack_level
 from ..accessors import DatasetAccessor, FetchAccessor, IterAccessor
@@ -354,6 +355,25 @@ class WSIData(SpatialData):
         else:
             return fromarray(img)
 
+    def _materialize_images_backed_by_store(self) -> None:
+        """
+        Materialize in-memory any image elements that are backed by the same
+        zarr store we are about to overwrite, so write() does not read zeros
+        from the already-cleared store. Only DataArrays are re-wrapped as dask
+        so Image2DModel schema still validates; DataTrees (e.g. WSI pyramid)
+        are left as-is to avoid schema issues.
+        """
+        from dask import array as dask_array
+
+        for key in list(self.images.keys()):
+            el = self.images[key]
+            if isinstance(el, DataArray):
+                if hasattr(el.data, "dask") and el.data.dask is not None:
+                    computed = el.compute()
+                    self.images[key] = computed.copy(
+                        data=dask_array.from_array(computed.data, chunks=computed.shape)
+                    )
+
     def write(
         self,
         file_path=None,
@@ -372,6 +392,9 @@ class WSIData(SpatialData):
                     "Please set the store path before saving."
                 )
             file_path = self._wsi_store
+        if overwrite and self.path is not None:
+            if Path(file_path).absolute() == Path(self.path).absolute():
+                self._materialize_images_backed_by_store()
         super().write(
             file_path=file_path,
             overwrite=overwrite,


### PR DESCRIPTION
Fixes #52 (original issue: https://github.com/rendeirolab/wsidata/issues/52)

**Minimal code to reproduce the issue:**

```python
# 1. Open WSI, write non-zero roi to store
wsi = open_wsi(wsi=wsi_path, store=str(store_dir))
wsi.images["roi"] = Image2DModel.parse(roi_array, dims=("c", "y", "x"), c_coords=[...])
wsi.write(store_dir)
assert read_zarr(store_dir)["roi"].max().compute() > 0  # OK

# 2. Re-open same WSI with same store, do NOT set roi again
wsi_second = open_wsi(wsi=wsi_path, store=str(store_dir))
wsi_second.write(store_dir)  # overwrites store

# 3. Bug: previously stored roi is now zeroed
assert read_zarr(store_dir)["roi"].max().compute() > 0  # FAILS (was zeroed)
```

**Summary**

**Root cause (from logs):** In-memory state was correct (e.g. `sdata.images` and `write()` via `_gen_elements` both had `"roi"`). The bug is in SpatialData’s `write()`: it calls `zarr.create_group(store=..., overwrite=True)`, which clears the whole store, then writes each element. The `"roi"` image is a dask-backed array loaded from that same store, so when it’s written it is read from the store that was just cleared → zeros get written.

**Fix:** In `WSIData.write()` we detect when we are overwriting the same store we’re backed by (`overwrite=True` and `file_path == self.path`). In that case we call `_materialize_images_backed_by_store()` before `super().write()`. That method: (1) loops over image elements that are DataArrays (e.g. `"roi"`); (2) if dask-backed, computes to memory; (3) re-wraps in a dask array (single chunk) so Image2DModel schema still passes. So `"roi"` is written from in-memory data. DataTree images (e.g. WSI pyramid) are left as-is; only store-backed DataArrays are materialized.

**Code changes:** `wsidata/_model/core.py`: added `_materialize_images_backed_by_store()` and a call in `write()` when overwriting the same store; imports for `DataArray` and `dask.array`. Test `test_wsi_write_keeps_existing_roi_when_rewriting_without_resetting_image` passes.
