### PR TITLE
perf: reduce import time

### DIFF
--- a/wsidata/__init__.py
+++ b/wsidata/__init__.py
@@ -4,10 +4,7 @@ from ._version import version
 
 __version__ = version
 
-import wsidata.dataset as dataset
-
 from ._model import TileRequest, TileSpec, WSIData, shapes2tiles
-from ._normalizer import ColorNormalizer
 from .accessors import (
     DatasetAccessor,
     FetchAccessor,
@@ -16,6 +13,29 @@ from .accessors import (
 )
 from .io import agg_wsi, concat_feature_anndata, open_wsi
 from .reader import READERS, SlideProperties
+
+
+def __getattr__(name):
+    # Lazily expose the `dataset` submodule and `ColorNormalizer` so that
+    # `import wsidata` does not eagerly import torch (both pull torch at
+    # definition time: torch.utils.data.Dataset subclasses / torch.nn.Module).
+    if name == "dataset":
+        import importlib
+
+        mod = importlib.import_module(".dataset", __name__)
+        globals()[name] = mod
+        return mod
+    if name == "ColorNormalizer":
+        from ._normalizer import ColorNormalizer
+
+        globals()[name] = ColorNormalizer
+        return ColorNormalizer
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(list(globals().keys()) + ["dataset", "ColorNormalizer"])
+
 
 __all__ = [
     "open_wsi",


### PR DESCRIPTION
Reduce import time of wsidata by making `dataset` and `ColorNormalizer` modules lazily loaded.